### PR TITLE
Implemented RefreshOnDelete functionality in IElasticsearchRepository

### DIFF
--- a/src/Nest.Queryify/Abstractions/IElasticsearchRepository.cs
+++ b/src/Nest.Queryify/Abstractions/IElasticsearchRepository.cs
@@ -58,16 +58,18 @@ namespace Nest.Queryify.Abstractions
         /// <typeparam name="T"></typeparam>
         /// <param name="document"></param>
         /// <param name="index">(optional) index on which to execute the query, if not supplied the index default index will be used</param>
+        /// <param name="refreshOnDelete">specifies whether to refresh the search index after completing the delete operation, only use when you understand the impact</param>
         /// <returns></returns>
-        IDeleteResponse Delete<T>(T document, string index = null) where T : class;
+        IDeleteResponse Delete<T>(T document, string index = null, bool? refreshOnDelete = null) where T : class;
         /// <summary>
         /// Removes an individual item identified by <paramref name="id"/>
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <param name="index">(optional) index on which to execute the query, if not supplied the index default index will be used</param>
+        /// <param name="refreshOnDelete">specifies whether to refresh the search index after completing the delete operation, only use when you understand the impact</param>
         /// <returns></returns>
-        IDeleteResponse Delete<T>(string id, string index = null) where T : class;
+        IDeleteResponse Delete<T>(string id, string index = null, bool? refreshOnDelete = null) where T : class;
         /// <summary>
         /// Determines whether <paramref name="document"/> exists in the given index
         /// </summary>

--- a/src/Nest.Queryify/ElasticsearchRepository.cs
+++ b/src/Nest.Queryify/ElasticsearchRepository.cs
@@ -64,14 +64,14 @@ namespace Nest.Queryify
 	        return Query(new BulkIndexDocumentQuery<T>(documents, refreshOnSave.GetValueOrDefault(false)), index);
         }
 
-        public IDeleteResponse Delete<T>(T document, string index = null) where T : class
+        public IDeleteResponse Delete<T>(T document, string index = null, bool? refreshOnDelete = null) where T : class
         {
-	        return Query(new DeleteDocumentQuery<T>(document), index);
+	        return Query(new DeleteDocumentQuery<T>(document, refreshOnDelete.GetValueOrDefault(false)), index);
         }
 
-		public IDeleteResponse Delete<T>(string id, string index = null) where T : class
+		public IDeleteResponse Delete<T>(string id, string index = null, bool? refreshOnDelete = null) where T : class
 		{
-			return Query(new DeleteByIdQuery<T>(id), index);
+			return Query(new DeleteByIdQuery<T>(id, refreshOnDelete.GetValueOrDefault(false)), index);
 		}
 
         public bool Exists<T>(string id, string index = null) where T : class

--- a/src/Nest.Queryify/Queries/Common/DeleteByIdQuery.cs
+++ b/src/Nest.Queryify/Queries/Common/DeleteByIdQuery.cs
@@ -6,20 +6,35 @@ namespace Nest.Queryify.Queries.Common
     public class DeleteByIdQuery<T> : ElasticClientQueryObject<IDeleteResponse> where T : class
     {
         private readonly string _id;
+        private readonly bool _refreshOnDelete;
 
-        public DeleteByIdQuery(string id)
+        public DeleteByIdQuery(string id, bool refreshOnDelete = false)
         {
             _id = id;
+            _refreshOnDelete = refreshOnDelete;
         }
 
         protected override IDeleteResponse ExecuteCore(IElasticClient client, string index)
         {
-            return client.Delete<T>(descriptor => descriptor.Id(_id).Index(index));
+            return client.Delete<T>(descriptor => BuildQueryCore(descriptor).Index(index));
         }
 
         protected override Task<IDeleteResponse> ExecuteCoreAsync(IElasticClient client, string index)
         {
-            return client.DeleteAsync<T>(descriptor => descriptor.Id(_id).Index(index));
+            return client.DeleteAsync<T>(descriptor => BuildQueryCore(descriptor).Index(index));
+        }
+
+        protected virtual DeleteDescriptor<T> BuildQueryCore(DeleteDescriptor<T> descriptor)
+        {
+            descriptor = descriptor
+                .Id(_id)
+                .Refresh(_refreshOnDelete);
+            return BuildQuery(descriptor);
+        }
+
+        protected virtual DeleteDescriptor<T> BuildQuery(DeleteDescriptor<T> descriptor)
+        {
+            return descriptor;
         }
     }
 }

--- a/src/Nest.Queryify/Queries/IndexDocumentQuery.cs
+++ b/src/Nest.Queryify/Queries/IndexDocumentQuery.cs
@@ -28,7 +28,7 @@ namespace Nest.Queryify.Queries
 		{
 			descriptor = descriptor
 				.Type<T>()
-				.Refresh(_refreshOnSave);
+				.Refresh(refreshOnSave);
 			return BuildQuery(descriptor);
 		}
 


### PR DESCRIPTION
Also made modification to the IndexDocumentQuery where inside BuildQueryCore it accepts a `bool refreshOnSave` parameter but then proceeded to use the private instance `_refreshOnSave`.

The additions for adding RefreshOnDelete functionality all use the private instance `_refreshOnDelete` inside their `BuildQueryCore` methods, but I thought I'd fix the "issue" in IndexDocumentQuery instead of change the way it functions entirely.
